### PR TITLE
Cut keybinds, some copy keybinds too and delete->copy functionality in existing commands

### DIFF
--- a/src/keybind/builtin/vim.json
+++ b/src/keybind/builtin/vim.json
@@ -13,8 +13,8 @@
             ["b", "move_word_left_vim"],
             ["w", "move_word_right_vim"],
             ["e", "move_word_right_end_vim"],
-            ["x", "delete_forward"],
-            ["s", ["delete_forward"], ["enter_mode", "insert"]],
+            ["x", "cut_forward_internal"],
+            ["s", ["cut_forward_internal"], ["enter_mode", "insert"]],
             ["u", "undo"],
 
             ["j", "move_down"],
@@ -48,7 +48,7 @@
             ["G", "move_buffer_end"],
 
             ["d$", "delete_to_end"],
-            ["dd", "cut"],
+            ["dd", "cut_internal"],
             ["\"_dd", "delete_line"],
 
             ["yy", "copy_line"],
@@ -78,7 +78,11 @@
             ["k", "select_up"],
             ["j", "select_down"],
             ["h", "select_left"],
-            ["l", "select_right"]
+            ["l", "select_right"],
+
+            ["x", ["cut_forward_internal"], ["enter_mode", "normal"]],
+            ["d", ["cut_forward_internal"], ["enter_mode", "normal"]],
+            ["s", ["cut_forward_internal"], ["enter_mode", "insert"]]
         ]
     },
     "insert": {

--- a/src/keybind/builtin/vim.json
+++ b/src/keybind/builtin/vim.json
@@ -13,6 +13,8 @@
         "press": [
             ["b", "move_word_left_vim"],
             ["w", "move_word_right_vim"],
+            ["W", "move_word_right"],
+            ["B", "move_word_left"],
             ["e", "move_word_right_end_vim"],
             ["x", "cut_forward_internal"],
             ["s", ["cut_forward_internal"], ["enter_mode", "insert"]],
@@ -39,7 +41,7 @@
             ["^", "smart_move_begin"],
             ["$", "move_end"],
             [":", "open_command_palette"],
-            ["p", "paste"],
+            ["p", "paste_internal_vim"],
 
             ["gi", "goto_implementation"],
             ["gy", "goto_type_definition"],
@@ -51,10 +53,10 @@
             ["d$", "delete_to_end"],
             ["dw", "cut_word_right_vim"],
             ["db", "cut_word_left_vim"],
-            ["dd", "cut_internal"],
+            ["dd", "cut_internal_vim"],
             ["\"_dd", "delete_line"],
 
-            ["yy", "copy_line"],
+            ["yy", ["copy_line_internal_vim"], ["cancel"]],
 
             ["<C-u>", "move_scroll_page_up"],
             ["<C-d>", "move_scroll_page_down"],
@@ -86,9 +88,11 @@
             ["h", "select_left"],
             ["l", "select_right"],
 
-            ["x", ["cut_forward_internal"], ["enter_mode", "normal"]],
-            ["d", ["cut_forward_internal"], ["enter_mode", "normal"]],
-            ["s", ["cut_forward_internal"], ["enter_mode", "insert"]]
+            ["y", ["copy_internal_vim"], ["cancel"], ["enter_mode", "normal"]],
+
+            ["x", ["cut_forward_internal"], ["cancel"], ["enter_mode", "normal"]],
+            ["d", ["cut_forward_internal"], ["cancel"], ["enter_mode", "normal"]],
+            ["s", ["cut_forward_internal"], ["cancel"], ["enter_mode", "insert"]]
         ]
     },
     "insert": {

--- a/src/keybind/builtin/vim.json
+++ b/src/keybind/builtin/vim.json
@@ -9,7 +9,7 @@
         "name": "NORMAL",
         "line_numbers": "relative",
         "cursor": "block",
-        "selection": "inclusive",
+        "selection": "normal",
         "press": [
             ["b", "move_word_left_vim"],
             ["w", "move_word_right_vim"],
@@ -32,15 +32,15 @@
             ["O", ["smart_insert_line_before"], ["enter_mode", "insert"]],
 
             ["v", "enter_mode", "visual"],
+            ["V", ["move_begin"], ["enter_mode", "visual"], ["select_end"]],
 
-            ["/", "find"],
             ["n", "goto_next_match"],
             ["0", "move_begin"],
+            ["^", "smart_move_begin"],
             ["$", "move_end"],
             [":", "open_command_palette"],
             ["p", "paste"],
 
-            ["gd", "goto_definition"],
             ["gi", "goto_implementation"],
             ["gy", "goto_type_definition"],
             ["gg", "move_buffer_begin"],
@@ -49,6 +49,8 @@
             ["G", "move_buffer_end"],
 
             ["d$", "delete_to_end"],
+            ["dw", "cut_word_right_vim"],
+            ["db", "cut_word_left_vim"],
             ["dd", "cut_internal"],
             ["\"_dd", "delete_line"],
 
@@ -62,10 +64,12 @@
             ["<C-i>", "jump_forward"],
             ["<C-y>", "redo"],
 
+            ["/", "find"],
+
             ["<C-k>", "TODO"],
 
-            ["<C-CR>", "smart_insert_line_after"],
-            ["<CR>", "smart_insert_line"]
+            ["<C-CR>", ["move_down"], ["move_begin"]],
+            ["<CR>", ["move_down"], ["move_begin"]]
         ]
     },
     "visual": {
@@ -73,8 +77,8 @@
         "on_match_failure": "ignore",
         "name": "VISUAL",
         "line_numbers": "relative",
-        "cursor": "underline",
-        "selection": "inclusive",
+        "cursor": "block",
+        "selection": "normal",
         "press": [
             ["<Esc>", "enter_mode", "normal"],
             ["k", "select_up"],
@@ -97,7 +101,10 @@
             ["<Esc>", "enter_mode", "normal"],
             ["<Del>", "delete_forward"],
             ["<BS>", "delete_backward"],
-            ["<CR>", "insert_line_after"]
+            ["<CR>", "smart_insert_line"],
+
+            ["<C-BS>", "delete_word_left"],
+            ["<C-Del", "delete_word_right"]
         ]
     },
     "home": {

--- a/src/keybind/builtin/vim.json
+++ b/src/keybind/builtin/vim.json
@@ -9,6 +9,7 @@
         "name": "NORMAL",
         "line_numbers": "relative",
         "cursor": "block",
+        "selection": "inclusive",
         "press": [
             ["b", "move_word_left_vim"],
             ["w", "move_word_right_vim"],
@@ -73,6 +74,7 @@
         "name": "VISUAL",
         "line_numbers": "relative",
         "cursor": "underline",
+        "selection": "inclusive",
         "press": [
             ["<Esc>", "enter_mode", "normal"],
             ["k", "select_up"],

--- a/src/tui/editor.zig
+++ b/src/tui/editor.zig
@@ -2421,7 +2421,6 @@ pub const Editor = struct {
         var all_stop = true;
         var root = root_;
 
-        // For each cursor, collect what would be deleted
         var text = std.ArrayList(u8).init(self.allocator);
         var first = true;
         for (self.cursels.items) |*cursel_| if (cursel_.*) |*cursel| {
@@ -2587,14 +2586,6 @@ pub const Editor = struct {
     }
     pub const delete_forward_meta = .{ .description = "Delete next character" };
 
-    pub fn delete_backward(self: *Self, _: Context) Result {
-        const b = try self.buf_for_update();
-        const root = try self.delete_to(move_cursor_left, b.root, b.allocator);
-        try self.update_buf(root);
-        self.clamp();
-    }
-    pub const delete_backward_meta = .{ .description = "Delete previous character" };
-
     pub fn cut_forward_internal(self: *Self, _: Context) Result {
         const b = try self.buf_for_update();
         const text, const root= try self.cut_to(move_cursor_right, b.root);
@@ -2602,7 +2593,15 @@ pub const Editor = struct {
         try self.update_buf(root);
         self.clamp();
     }
-    pub const cut_forward_internal_meta = .{ .description = "Cut next character" };
+    pub const cut_forward_internal_meta = .{ .description = "Cut next character to internal clipboard" };
+
+    pub fn delete_backward(self: *Self, _: Context) Result {
+        const b = try self.buf_for_update();
+        const root = try self.delete_to(move_cursor_left, b.root, b.allocator);
+        try self.update_buf(root);
+        self.clamp();
+    }
+    pub const delete_backward_meta = .{ .description = "Delete previous character" };
 
     pub fn delete_word_left(self: *Self, _: Context) Result {
         const b = try self.buf_for_update();
@@ -2612,6 +2611,15 @@ pub const Editor = struct {
     }
     pub const delete_word_left_meta = .{ .description = "Delete previous word" };
 
+    pub fn cut_word_left_vim(self: *Self, _: Context) Result {
+        const b = try self.buf_for_update();
+        const text, const root= try self.cut_to(move_cursor_word_left_vim, b.root);
+        self.set_clipboard_internal(text);
+        try self.update_buf(root);
+        self.clamp();
+    }
+    pub const cut_word_left_vim_meta = .{ .description = "Cut next character to internal clipboard" };
+
     pub fn delete_word_right(self: *Self, _: Context) Result {
         const b = try self.buf_for_update();
         const root = try self.delete_to(move_cursor_word_right_space, b.root, b.allocator);
@@ -2619,6 +2627,15 @@ pub const Editor = struct {
         self.clamp();
     }
     pub const delete_word_right_meta = .{ .description = "Delete next word" };
+
+    pub fn cut_word_right_vim(self: *Self, _: Context) Result {
+        const b = try self.buf_for_update();
+        const text, const root= try self.cut_to(move_cursor_word_right_vim, b.root);
+        self.set_clipboard_internal(text);
+        try self.update_buf(root);
+        self.clamp();
+    }
+    pub const cut_word_right_vim_meta = .{ .description = "Cut next character to internal clipboard" };
 
     pub fn delete_to_begin(self: *Self, _: Context) Result {
         const b = try self.buf_for_update();


### PR DESCRIPTION
Added `paste_internal_vim` and `copy_internal_vim` functions that use the internal clipboard buffer only and act like the vim copy/paste.
Added `cut_internal_vim` that acts like vim cut.
Changed delete_forward in x/s to be `cut_forward_internal` which fills the internal clipboard, like vim.
Added support for word cuts with `cut_word_right_vim` and `cut_word_left_vim`.

Some specific quirks are not exactly ironed out, but I think now the editor behaves a lot more like vim, and it's usable, at least for me 😁.